### PR TITLE
link with rustc_driver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![crate_type = "dylib"]
 #![feature(plugin_registrar, rustc_private)]
 
+extern crate rustc_driver;
 extern crate rustc_plugin;
 extern crate syntax;
 extern crate syntax_pos;


### PR DESCRIPTION
To prevent the error we see when compiling cargo-snippet 0.3 with the nightly (1.40) rustc_driver should be linked with.
thread 'rustc' panicked at 'cannot access a scoped thread local variable without calling `set` first', /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-1.0.0/src/lib.rs:168:9

ref: https://github.com/rust-lang/rust/issues/63283

Signed-off-by: Akira Hayakawa <ruby.wktk@gmail.com>