### PR TITLE
Support prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ fn gcd_list(list: &[u64]) -> u64 {
     list.iter().fold(list[0], |a, &b| gcd(a, b))
 }
 
+// You can set prefix string.
+// Note: All codes will be formatted by rustfmt on output
+#[snippet(prefix = "use std::io::{self,Read};")]
+#[snippet(prefix = "use std::str::FromStr;")]
+fn foo() {}
+
 #[test]
 fn test_gcd() {
     assert_eq!(gcd(57, 3), 3);
@@ -91,6 +97,11 @@ Extract snippet !
 
 ```
 $ cargo snippet
+snippet foo
+    use std::io::{self, Read};
+    use std::str::FromStr;
+    fn foo() {}
+
 snippet gcd
     fn gcd(a: u64, b: u64) -> u64 {
         if b == 0 {
@@ -109,7 +120,7 @@ snippet gcd_list
         }
     }
     fn gcd_list(list: &[u64]) -> u64 {
-        list.iter().fold(list[0], |a, b| gcd(a, b));
+        list.iter().fold(list[0], |a, &b| gcd(a, b))
     }
 
 snippet lcm

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -198,6 +198,40 @@ fn get_snippet_uses(attr: &Attribute) -> Option<Vec<String>> {
     })
 }
 
+fn get_simple_attr(attr: &Attribute, key: &str) -> Vec<String> {
+    attr.parse_meta()
+        .ok()
+        .and_then(|metaitem| {
+            if !is_snippet_path(metaitem.path().to_token_stream().to_string().as_str()) {
+                return None;
+            }
+
+            match metaitem {
+                // #[snippet(`key`="..")]
+                Meta::List(list) => list
+                    .nested
+                    .iter()
+                    .filter_map(|item| {
+                        if let NestedMeta::Meta(Meta::NameValue(ref nv)) = item {
+                            if nv.path.to_token_stream().to_string() == key {
+                                let value =
+                                    unquote(&nv.lit.clone().into_token_stream().to_string());
+                                Some(value)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .into(),
+                _ => None,
+            }
+        })
+        .unwrap_or(Vec::new())
+}
+
 fn parse_attrs(
     attrs: &[Attribute],
     default_snippet_name: Option<String>,
@@ -246,7 +280,18 @@ fn parse_attrs(
         .flat_map(|v| v.into_iter())
         .collect::<HashSet<_>>();
 
-    Some(SnippetAttributes { names, uses })
+    let prefix = attrs
+        .iter()
+        .map(|attr| get_simple_attr(attr, "prefix").into_iter())
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(SnippetAttributes {
+        names,
+        uses,
+        prefix,
+    })
 }
 
 // Get snippet names and snippet code (not formatted)
@@ -631,10 +676,48 @@ mod test {
         "#;
 
         let snip = snippets(&src);
-        dbg!(&snip);
         assert_eq!(
             format_src(snip["bar"].as_str()).unwrap(),
             format_src("fn bar() {}").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_attribute_prefix() {
+        let src = r#"
+            #[snippet(prefix = "use std::io;")]
+            fn bar() {}
+        "#;
+
+        let snip = snippets(&src);
+        assert_eq!(
+            format_src(snip["bar"].as_str()).unwrap(),
+            format_src("use std::io;\nfn bar() {}").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_attribute_prefix_include() {
+        let src = r#"
+            #[snippet(prefix = "use std::sync;")]
+            fn foo() {}
+            #[snippet(prefix = "use std::io;", include = "foo")]
+            fn bar() {}
+        "#;
+
+        let snip = snippets(&src);
+        assert_eq!(
+            format_src(snip["bar"].as_str()).unwrap(),
+            format_src(
+                &quote!(
+                    use std::sync;
+                    use std::io;
+                    fn foo() {}
+                    fn bar() {}
+                )
+                .to_string()
+            )
+            .unwrap()
         );
     }
 }


### PR DESCRIPTION
スニペットの最初に文字列を追加できるようにしました

```rust
#[snippet(prefix = "use std::io;")]
fn bar() {}
```
が
```rust
use std::io;
fn bar() {}
```
に展開されます