### PR TITLE
Output doc comments in 3-slash-style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ required-features = ["binaries"]
 [dependencies]
 syn = { version = "1", features = ["full", "parsing", "extra-traits", "printing"], optional = true }
 quote = { version = "1", optional = true }
+proc-macro2 = { version = "1", optional = true }
 rustfmt-nightly = { version = "1", optional = true }
 glob = { version = "0.3", optional = true }
 clap = { version = "2.29", optional = true }
@@ -30,7 +31,9 @@ serde_derive = { version = "1.0", optional = true}
 serde_json = { version = "1.0", optional = true}
 log = { version= "0.4", optional = true }
 env_logger = { version= "0.7", optional = true }
+regex = { version = "1.3.5", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 [features]
-binaries = ["syn", "quote", "glob", "clap", "serde", "serde_derive", "serde_json", "log", "env_logger"]
+binaries = ["syn", "quote", "proc-macro2", "glob", "clap", "serde", "serde_derive", "serde_json", "log", "env_logger", "regex", "lazy_static"]
 inner_rustfmt = ["rustfmt-nightly"]

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
+#[derive(Debug)]
 pub struct SnippetAttributes {
     // A snippet with multiple names is allowed but using dependency is recommended.
     pub names: HashSet<String>,
@@ -9,6 +10,7 @@ pub struct SnippetAttributes {
     pub prefix: String,
 }
 
+#[derive(Debug)]
 pub struct Snippet {
     pub attrs: SnippetAttributes,
     // Snippet content (Not formated)


### PR DESCRIPTION
Thanks for the awesome tool. Without this tool, my competitive programming days would be more annoying.

This PR solves #13 

Line doc comments like `/// foo` or `//! bar` are easy to be dealt with, but block ones like `/** foo */` are pretty complicated.
So I added regex crate, processing it with regular expression's approach.
Please let me know if this is not a preferable way.

I have checked this code works well for [my library](https://github.com/magurotuna/libprocon) and [your library](https://github.com/hatoo/competitive-rust-snippets).